### PR TITLE
Make sure "Shank & Wrot, Orc Scavengers" cannot lead troops

### DIFF
--- a/data2024.json
+++ b/data2024.json
@@ -3448,7 +3448,7 @@
 				"options": [],
 				"specialRules": [],
 				"increaseMaximumChildren": {
-					"warriors": -2
+					"warriors": -6
 				}
 			},
 			{


### PR DESCRIPTION
According to the wording of the book it should be impossible to add warriors to the warband of Shank and Wrot;

> "Shank & Wrot, Orc Scavengers, is made up of Shank, Wrot and a Snow Troll, and will count as three models. Shank is always the Captain of the Warband with Wrot and the Snow Troll as his Followers; Wrot always counts as an Independent Hero in Shank’s Warband. No other models may be part of Shank’s Warband."

I'm am not sure if the is the correct way to change the data for Shank & Wrot as I am unfamiliar with this data file. Though in my own test I saw I was unable to add any new warriors. 

Hopefully this is correct ;) 