### PR TITLE
BUGFIX: Add Citadel Guards to Boromir, Captain of the White Tower in data2024.json

### DIFF
--- a/data2024.json
+++ b/data2024.json
@@ -37896,6 +37896,16 @@
 								"in": "Boromir, Captain of the White Tower"
 							},
 							{
+								"in": "Reclamation of Osgiliath"
+							}
+						]
+					},
+					{
+						"all": [
+							{
+								"in": "Boromir, Captain of the White Tower"
+							},
+							{
 								"in": "Minas Tirith"
 							}
 						]


### PR DESCRIPTION
Add Citadel Guards to Boromir, Captain of the White Tower in data2024.json